### PR TITLE
API extention request

### DIFF
--- a/README.md
+++ b/README.md
@@ -1261,6 +1261,12 @@ Get tags
   {
     "id": 123,
     "name": "vip-customer"
+    "labels: [
+      { 
+        "id": 123,
+        "name": "tag-label-123"
+      }
+    ]
   }
 ]
 ```
@@ -1269,6 +1275,20 @@ Get tag by ID
 -------------
 
 `GET /tags/123.json` will get a tag by its ID.
+
+**Response:**
+
+```json
+{
+  "id": 123,
+  "name": "vip-customer"
+}
+```
+
+Get tag by name
+-------------
+
+`GET /tags/tag_name.json` will get a tag by its name.
 
 **Response:**
 


### PR DESCRIPTION
For integration with Notion via Windmill, we do need two things:
1. to get the labels that are associated with tags
2. to fetch tag info by name (when the specific tag name is known but not the id)

i guess this is a non-standard way of asking for a new API feature, but i am most comfortable with issues and PRs and didn't find a better way. Happy to also cross post and/or open a Help Request if that's better for the team.