### PR TITLE
Add deprecation notice pointing to /api/v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+> ⚠️ **Deprecated:** This API (`/api/v1`) is deprecated. Please use `/api/v2`, which supports many more resources.
+>
+> - **Docs:** https://simplero.com/api/v2/docs
+> - **OpenAPI spec:** https://simplero.com/api/v2/docs/openapi.json
+>
+> The endpoints documented below remain available so existing integrations keep working, but new integrations should use `/api/v2`.
+
 The API is REST, using JSON for serialization, with no root element.
 
 We also have one webhook endpoint available. See the bottom of this file.


### PR DESCRIPTION
## Summary
- Adds a deprecation banner at the top of the README pointing users at `/api/v2`, with links to https://simplero.com/api/v2/docs and the OpenAPI spec at https://simplero.com/api/v2/docs/openapi.json.
- Keeps the rest of the README intact so integrations still on `/api/v1` retain their reference docs.

Companion to https://github.com/Simplero/Simplero/pull/31766, which added a `deprecation_notice` field and RFC 9745 `Deprecation`/`Link`/`Warning` headers to legacy `/api/v1` responses.

SDev task: http://sdev.run/tasks/157?expanded=true

## Test plan
- [x] Verified URLs match the legacy API deprecation middleware constants.
- [ ] Render README on GitHub to confirm the blockquote callout displays as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added deprecation warning for API v1 directing users to migrate to API v2.
  * Published API v2 documentation and OpenAPI specification references.
  * Clarified that existing API v1 endpoints remain available for backward compatibility; new integrations should use API v2.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Simplero/Simplero-API/pull/24?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->